### PR TITLE
Crows EW settings

### DIFF
--- a/cba_settings.sqf
+++ b/cba_settings.sqf
@@ -1077,20 +1077,20 @@ cba_ui_notifyLifetime = 4;
 cba_ui_StorePasswords = 1;
 
 // Crows Electronic Warfare
-force force crowsEW_spectrum_defaultClassForJammingSignal = "UGV_01_base_F,UGV_02_Base_F,UAV_01_base_F,UAV_02_base_F,UAV_03_base_F,UAV_04_base_F,UAV_05_Base_F,UAV_06_base_F,GX_HONEYBADGER_UGV_BASE,GX_BLACK_HORNET_UAV_BASE,GX_DRONE40_UAV_BASE,shahed_base_F,shahed_base_F";
-force force crowsEW_spectrum_minJamSigStrength = -40;
-force force crowsEW_spectrum_selfTracking = false;
-crowsEW_spectrum_spectrumAutoline = true;
-crowsEW_spectrum_spectrumAutolineColor1 = 2;
-crowsEW_spectrum_spectrumAutolineColor2 = 7;
-crowsEW_spectrum_spectrumAutolineColor3 = 8;
-crowsEW_spectrum_spectrumAutolineColor4 = 5;
-crowsEW_spectrum_spectrumAutolineLength = 6000;
-crowsEW_spectrum_spectrumAutolineNoise = 0;
 force force crowsEW_spectrum_spectrumEnable = true;
-force force crowsEW_spectrum_tfarSideTrack = false;
-force force crowsEW_main_zeus_jam_immune = false;
+force force crowsEW_spectrum_defaultClassForJammingSignal = "UGV_01_base_F,UGV_02_Base_F,UAV_01_base_F,UAV_02_base_F,UAV_03_base_F,UAV_04_base_F,UAV_05_Base_F,UAV_06_base_F,GX_HONEYBADGER_UGV_BASE,GX_BLACK_HORNET_UAV_BASE,GX_DRONE40_UAV_BASE,shahed_base_F,shahed_base_F";
+force force crowsEW_spectrum_minJamSigStrength = -60;
+force force crowsEW_spectrum_tfarSideTrack = true;
+force force crowsEW_spectrum_selfTracking = true;
+force force crowsEW_main_zeus_jam_immune = true;
 force force crowsEW_main_zeus_jam_marker_show = true;
+crowsEW_spectrum_spectrumAutoline = true;
+crowsEW_spectrum_spectrumAutolineColor1 = 10;
+crowsEW_spectrum_spectrumAutolineColor2 = 4;
+crowsEW_spectrum_spectrumAutolineColor3 = 3;
+crowsEW_spectrum_spectrumAutolineColor4 = 0;
+crowsEW_spectrum_spectrumAutolineLength = 5000;
+force force crowsEW_spectrum_spectrumAutolineNoise = 0;
 
 // Crows Zeus Additions
 crowsza_pingbox_CBA_Setting_enabled = true;


### PR DESCRIPTION
- temporary lower jam strength requirement, until range can be increased in next crows EW mod update
- tfar side track and self track enabled:
  - this does NOT enable radio tracking
  - this does nothing while radio tracking is disabled
  - if radio tracking were to be enabled (which is not done through cba settings), we'd want these turned on
- zeuses made immune to radio jamming, would be silly if they can't talk because of a radio jammer they themselves put down
- default autoline colors adjusted so people don't start drawing random squad colored lines all over the map on accident
  - default line is now white (unused), others are orange (unused), brown (dark orange, unused) and black
- force autoline noise off, don't need it, don't want it, makes no sense to have it, especially not client side